### PR TITLE
Add resource failure when in error state

### DIFF
--- a/lib/puppetx/filemapper.rb
+++ b/lib/puppetx/filemapper.rb
@@ -9,6 +9,7 @@ module PuppetX::FileMapper
   #
   # This method is necessary for the provider to be ensurable
   def create
+    raise Puppet::Error, "#{self.class} is in an error state" if self.class.failed?
     @resource.class.validproperties.each do |property|
       if value = @resource.should(property)
         @property_hash[property] = value


### PR DESCRIPTION
Note: I actually don't know and haven't tested well multi-file implications of the implementation in the pull request for the problem described below.

Previously, a filemapper provider could fail to parse a file and enter an "error state", while in which the flush method would fail with an error. However, individual resource-level logs would indicate success. The following is an example log output.

  err: Could not prefetch mcollective_config provider 'filemapper':
    /etc/puppetlabs/mcollective/server.cfg is malformed; " = fabl" did not
    match "(?-mix:^\s_(\S+)\s_=\s_(\S+)\s_$)"
  notice: /Stage[main]//Mcollective_config[foo.value2]/ensure: created
  err: Puppet::Type::Mcollective_config::ProviderFilemapper: filemapper is
    in an error state, refusing to flush file
    /etc/puppetlabs/mcollective/server.cfg
  notice: /Stage[main]//Mcollective_config[foo.value1]/ensure: created
  err: Puppet::Type::Mcollective_config::ProviderFilemapper: filemapper is
    in an error state, refusing to flush file
    /etc/puppetlabs/mcollective/server.cfg
  notice: Finished catalog run in 0.11 seconds

Note the notice messages incorrectly indicating that the resources were successfully created (inbetween error messages that are less closely tied to individual resources).

This commit adds a check to the create method such that if the provider enters an error state the failure will occur per-resource, and not only at the end when trying to flush the resources to disk.

  err: Could not prefetch mcollective_config provider 'filemapper':
    /etc/puppetlabs/mcollective/server.cfg is malformed; " = fab" did not
    match "(?-mix:^\s_(\S+)\s_=\s_(\S+)\s_$)"
  err: /Stage[main]//Mcollective_config[foo.value2]/ensure: change from
    absent to present failed: foo.value2 is in an error state
  err: /Stage[main]//Mcollective_config[foo.value1]/ensure: change from
    absent to present failed: foo.value1 is in an error state
  notice: Finished catalog run in 0.10 seconds
