### PR TITLE
Pin redcarpet dependency to make Ruby 1.8.7 happy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'facter', '>= 1.6.2'
 
 group :test, :development do
   gem 'yard',  '~> 0.8.3'
-  gem 'redcarpet'
+  gem 'redcarpet', '~> 2.3.0'
   gem 'rspec', '~> 2.10.0'
   gem 'mocha', '~> 0.10.5'
 end


### PR DESCRIPTION
Travis tests for Ruby 1.8.7 have been failing because Redcarpet 3.x dropped
support for 1.8.x. Pin Redcarpet to 2.3.x to work around this.
