### PR TITLE
Sync mk_resource_methods with Puppet Core

### DIFF
--- a/lib/puppetx/filemapper.rb
+++ b/lib/puppetx/filemapper.rb
@@ -210,7 +210,11 @@ module PuppetX::FileMapper
 
         # Generate the attr_reader method
         define_method(attr) do
-          @property_hash[attr]
+          if @property_hash[attr].nil?
+            :absent
+          else
+            @property_hash[attr]
+          end
         end
 
         # Generate the attr_writer and have it mark the resource as dirty when called


### PR DESCRIPTION
`Puppet::Provider.mk_resource_methods` returns `:absent` instead of `nil`
where the FileMapper returns `nil`. This patch synchs with the core behavior.
