### PR TITLE
initvars needs a call to super

### DIFF
--- a/lib/puppetx/filemapper.rb
+++ b/lib/puppetx/filemapper.rb
@@ -72,6 +72,7 @@ module PuppetX::FileMapper
     attr_reader :mapped_files
 
     def initvars
+      super
       @mapped_files = Hash.new {|h, k| h[k] = {}}
       @unlink_empty_files = false
       @filetype = :flat


### PR DESCRIPTION
if it doesn't, and we inherit from a provider that implements filemapper
the prefetch method will end up empty handed.
