### PR TITLE
find the correct name of the namevar

### DIFF
--- a/lib/puppetx/filemapper.rb
+++ b/lib/puppetx/filemapper.rb
@@ -192,7 +192,10 @@ module PuppetX::FileMapper
 
       # generate hash of {provider_name => provider}
       providers = instances.inject({}) do |hash, instance|
-        hash[instance.name] = instance
+        # name is not necessarily the name_var.
+        # n.b. the following will fall flat for composite namevars.
+        namevar = resource_type.key_attributes.first
+        hash[instance.send(namevar)] = instance
         hash
       end
 


### PR DESCRIPTION
rather than relying on namevar always being name, we try to find the
correct one.

"of course", this will not work for composite namevars.

this addresses #1