### PR TITLE
Error: Puppet::Util::FileType::FileTypeFlat could not read absent fix

### DIFF
--- a/lib/puppetx/filemapper.rb
+++ b/lib/puppetx/filemapper.rb
@@ -169,11 +169,17 @@ module PuppetX::FileMapper
       # Read and parse each file.
       provider_hashes = []
       @mapped_files.each_pair do |filename, file_attrs|
-        arr = parse_file(filename, file_attrs[:filetype].read)
-        unless arr.is_a? Array
-          raise Puppet::DevError, "expected #{self}.parse_file to return an Array, got a #{arr.class}"
-        end
-        provider_hashes.concat arr
+	# The filetype path must be a type pathname, or it must respond to to_str
+	# If it doesn't meet these criteria go to next file
+	_path = file_attrs[:filetype].path
+       
+	if(_path.is_a?(Pathname) || _path.respond_to?(:to_str))
+          arr = parse_file(filename, file_attrs[:filetype].read)
+          unless arr.is_a? Array
+            raise Puppet::DevError, "expected #{self}.parse_file to return an Array, got a #{arr.class}"
+          end
+          provider_hashes.concat arr
+	end
       end
 
       provider_hashes


### PR DESCRIPTION
While running Puppet we got this error:

Error: Puppet::Util::FileType::FileTypeFlat could not read absent: FileSystem implementation expected Pathname, got: 'Symbol'

The exception occurs in the file puppet/file_system/file_impl.rb:

def assert_path(path)
    return path if path.is_a?(Pathname)

    # Some paths are string, or in the case of WatchedFile, it pretends to be
    # one by implementing to_str.
    if path.respond_to?(:to_str)
      Pathname.new(path)
    else
      raise ArgumentError, "FileSystem implementation expected Pathname, got: '#{path.class}'"
    end
  end

The solution does the same checks as assert_path. If the checks do not pass we do not go further since an exception will be raised.